### PR TITLE
ZERO-3071-ZERO-3109: Update notistack fork for the user notifications center

### DIFF
--- a/src/SnackbarProvider/SnackbarProvider.tsx
+++ b/src/SnackbarProvider/SnackbarProvider.tsx
@@ -105,7 +105,6 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
             SnackbarProps: merger('SnackbarProps', true),
             className: clsx(this.props.className, options.className),
             displayOrder: options.displayOrder ?? 0,
-            reverse: options.reverse ?? false,
         };
 
         if (snack.persist) {
@@ -309,17 +308,6 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
         const snackbars = Object.keys(categ).map((origin) => {
             const snacks = categ[origin];
             const [nomineeSnack] = snacks.sort((a, b) => a.displayOrder - b.displayOrder);
-            const reversedSnacks = snacks.filter(snack => snack.reverse);
-            if (reversedSnacks.length > 1) {
-                reversedSnacks.reverse();
-                let reversedIndex = 0;
-                for (let i = 0; i < snacks.length; i++) {
-                    if (snacks[i].reverse) {
-                    snacks[i] = reversedSnacks[reversedIndex];
-                    reversedIndex++;
-                    }
-                }
-            }
             return (
                 <SnackbarContainer
                     key={origin}

--- a/src/SnackbarProvider/SnackbarProvider.tsx
+++ b/src/SnackbarProvider/SnackbarProvider.tsx
@@ -104,6 +104,7 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
             style: merger('style', true),
             SnackbarProps: merger('SnackbarProps', true),
             className: clsx(this.props.className, options.className),
+            displayOrder: options.displayOrder ?? 0,
         };
 
         if (snack.persist) {
@@ -306,7 +307,7 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
 
         const snackbars = Object.keys(categ).map((origin) => {
             const snacks = categ[origin];
-            const [nomineeSnack] = snacks;
+            const [nomineeSnack] = snacks.sort((a, b) => a.displayOrder - b.displayOrder);
             return (
                 <SnackbarContainer
                     key={origin}

--- a/src/SnackbarProvider/SnackbarProvider.tsx
+++ b/src/SnackbarProvider/SnackbarProvider.tsx
@@ -307,36 +307,6 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
         const snackbars = Object.keys(categ).map((origin) => {
             const snacks = categ[origin];
             const [nomineeSnack] = snacks;
-
-             const categorizedSnacks: { [category: string]: InternalSnack[] } = {
-                call: [],
-                notification: [],
-                notificationViewAll: [],
-                regular: [],
-            };
-
-            snacks.forEach((snack: InternalSnack) => {
-                const snackId = String(snack.id);
-                let category = 'regular';
-
-                if (snackId.startsWith('call-')) {
-                    category = 'call';
-                } else if (snackId.startsWith('notification-')) {
-                    category = 'notification';
-                } else if (snackId === 'view_all_notifications') {
-                    category = 'notificationViewAll';
-                }
-
-                categorizedSnacks[category].push(snack);
-            });
-
-            const combinedSnacks = [
-                ...categorizedSnacks['call'],
-                ...categorizedSnacks['notification'].reverse(),
-                ...categorizedSnacks['notificationViewAll'],
-                ...categorizedSnacks['regular'],
-            ];
-
             return (
                 <SnackbarContainer
                     key={origin}
@@ -344,7 +314,7 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
                     anchorOrigin={nomineeSnack.anchorOrigin}
                     classes={classes}
                 >
-                    {combinedSnacks.map((snack) => (
+                    {snacks.map((snack) => (
                         <SnackbarItem
                             key={snack.id}
                             snack={snack}

--- a/src/SnackbarProvider/SnackbarProvider.tsx
+++ b/src/SnackbarProvider/SnackbarProvider.tsx
@@ -105,6 +105,7 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
             SnackbarProps: merger('SnackbarProps', true),
             className: clsx(this.props.className, options.className),
             displayOrder: options.displayOrder ?? 0,
+            reverse: options.reverse ?? false,
         };
 
         if (snack.persist) {
@@ -308,6 +309,17 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
         const snackbars = Object.keys(categ).map((origin) => {
             const snacks = categ[origin];
             const [nomineeSnack] = snacks.sort((a, b) => a.displayOrder - b.displayOrder);
+            const reversedSnacks = snacks.filter(snack => snack.reverse);
+            if (reversedSnacks.length > 1) {
+                reversedSnacks.reverse();
+                let reversedIndex = 0;
+                for (let i = 0; i < snacks.length; i++) {
+                    if (snacks[i].reverse) {
+                    snacks[i] = reversedSnacks[reversedIndex];
+                    reversedIndex++;
+                    }
+                }
+            }
             return (
                 <SnackbarContainer
                     key={origin}

--- a/src/SnackbarProvider/SnackbarProvider.tsx
+++ b/src/SnackbarProvider/SnackbarProvider.tsx
@@ -307,7 +307,7 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
 
         const snackbars = Object.keys(categ).map((origin) => {
             const snacks = categ[origin];
-            const [nomineeSnack] = snacks.sort((a, b) => a.displayOrder - b.displayOrder);
+            const [nomineeSnack] = snacks.sort((a, b) => b.displayOrder - a.displayOrder);
             return (
                 <SnackbarContainer
                     key={origin}

--- a/src/SnackbarProvider/SnackbarProvider.tsx
+++ b/src/SnackbarProvider/SnackbarProvider.tsx
@@ -307,6 +307,36 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
         const snackbars = Object.keys(categ).map((origin) => {
             const snacks = categ[origin];
             const [nomineeSnack] = snacks;
+
+             const categorizedSnacks: { [category: string]: InternalSnack[] } = {
+                call: [],
+                notification: [],
+                notificationViewAll: [],
+                regular: [],
+            };
+
+            snacks.forEach((snack: InternalSnack) => {
+                const snackId = String(snack.id);
+                let category = 'regular';
+
+                if (snackId.startsWith('call-')) {
+                    category = 'call';
+                } else if (snackId.startsWith('notification-')) {
+                    category = 'notification';
+                } else if (snackId === 'view_all_notifications') {
+                    category = 'notificationViewAll';
+                }
+
+                categorizedSnacks[category].push(snack);
+            });
+
+            const combinedSnacks = [
+                ...categorizedSnacks['call'],
+                ...categorizedSnacks['notification'].reverse(),
+                ...categorizedSnacks['notificationViewAll'],
+                ...categorizedSnacks['regular'],
+            ];
+
             return (
                 <SnackbarContainer
                     key={origin}
@@ -314,7 +344,7 @@ class SnackbarProvider extends Component<SnackbarProviderProps, State> {
                     anchorOrigin={nomineeSnack.anchorOrigin}
                     classes={classes}
                 >
-                    {snacks.map((snack) => (
+                    {combinedSnacks.map((snack) => (
                         <SnackbarItem
                             key={snack.id}
                             snack={snack}

--- a/src/types.ts
+++ b/src/types.ts
@@ -305,11 +305,6 @@ export interface OptionsObject<V extends VariantType = VariantType> extends Shar
      * @default 0
      */
      displayOrder?: number;
-    /**
-     * Reverse the order of a display. The reversed order is switched only in the snackbar that is already displayed.
-     * @default false
-     */
-    reverse?: boolean;
 }
 
 /** Properties of the internal snack which should not be exposed to outside world  */
@@ -329,8 +324,7 @@ type NeededByInternalSnack =
     | 'transitionDuration'
     | 'hideIconVariant'
     | 'disableWindowBlurListener'
-    | 'displayOrder'
-    | 'reverse';
+    | 'displayOrder';
 
 /**
  * Properties of a snackbar internal to notistack implementation. Not to be used by outside

--- a/src/types.ts
+++ b/src/types.ts
@@ -300,6 +300,11 @@ export interface OptionsObject<V extends VariantType = VariantType> extends Shar
      * @default false
      */
     persist?: boolean;
+    /**
+     * Order of a display. The order is switched only in the snackbar that is already displayed.
+     * @default 0
+     */
+     displayOrder?: number;
 }
 
 /** Properties of the internal snack which should not be exposed to outside world  */
@@ -318,7 +323,8 @@ type NeededByInternalSnack =
     | 'TransitionProps'
     | 'transitionDuration'
     | 'hideIconVariant'
-    | 'disableWindowBlurListener';
+    | 'disableWindowBlurListener'
+    | 'displayOrder';
 
 /**
  * Properties of a snackbar internal to notistack implementation. Not to be used by outside

--- a/src/types.ts
+++ b/src/types.ts
@@ -305,6 +305,11 @@ export interface OptionsObject<V extends VariantType = VariantType> extends Shar
      * @default 0
      */
      displayOrder?: number;
+    /**
+     * Reverse the order of a display. The reversed order is switched only in the snackbar that is already displayed.
+     * @default false
+     */
+    reverse?: boolean;
 }
 
 /** Properties of the internal snack which should not be exposed to outside world  */
@@ -324,7 +329,8 @@ type NeededByInternalSnack =
     | 'transitionDuration'
     | 'hideIconVariant'
     | 'disableWindowBlurListener'
-    | 'displayOrder';
+    | 'displayOrder'
+    | 'reverse';
 
 /**
  * Properties of a snackbar internal to notistack implementation. Not to be used by outside


### PR DESCRIPTION
## Linear Ticket
https://linear.app/ovice/issue/ZERO-3071/the-display-order-of-notification-snackbars-is-from-older-to-newer
https://linear.app/ovice/issue/ZERO-3109/incoming-call-snackbar-is-not-displayed-on-top-of-the-list-on

## Overview
This PR updates the notistack library code to prioritize the display of call snackbars at the top, succeeded by user notification snackbars, the "view all notifications" snackbar, and ultimately, the remaining regular snackbars.

So the priority to show snackbars in ovice-ui will be like the following:
1. call snackbars
2. user notifications snackbars
  * User notifications snackbars must be sorted in descending order
3. view all user notifications snackbar
4. all the other snackbars

If approved we will need to start using this fork in ovice-ui instead of the main notistack repository, and maintain it so that we can keep the changes synced.